### PR TITLE
Consolidate import path to use cloudfoundry.org/cli path

### DIFF
--- a/cmd/reportusage/main.go
+++ b/cmd/reportusage/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 
+	"code.cloudfoundry.org/cli/plugin"
 	"github.com/aegershman/cf-report-usage-plugin/internal/presentation"
 	"github.com/aegershman/cf-report-usage-plugin/internal/report"
-	"github.com/cloudfoundry/cli/plugin"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module github.com/aegershman/cf-report-usage-plugin
 go 1.15
 
 require (
-	code.cloudfoundry.org/cli v6.51.0+incompatible // indirect
+	code.cloudfoundry.org/cli v6.51.0+incompatible
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20200413172050-18981bf12b4b
-	github.com/cloudfoundry/cli v6.53.0+incompatible
 	github.com/google/go-cmp v0.4.1 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20200413172050-18981bf12b4b h1:DxtGfGx/LJEIa9ZswJw097bz6CGQdaq2m9XFFuzomg8=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20200413172050-18981bf12b4b/go.mod h1:RtIewdO+K/czvxvIFCMbPyx7jdxSLL1RZ+DA/Vk8Lwg=
-github.com/cloudfoundry/cli v6.53.0+incompatible h1:8oj3QwuibmLhhqXq+O9U/xMZEDl6zT+YIiTFSbEywUE=
-github.com/cloudfoundry/cli v6.53.0+incompatible/go.mod h1:uUVSLzSuwWNhis5+tY5XRUp66kLbHhBktg8b3ZfcJHI=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/report/client.go
+++ b/internal/report/client.go
@@ -1,8 +1,8 @@
 package report
 
 import (
+	"code.cloudfoundry.org/cli/plugin"
 	"github.com/aegershman/cf-report-usage-plugin/internal/v2client"
-	"github.com/cloudfoundry/cli/plugin"
 )
 
 // Client orchestrates generation and aggregation of report data

--- a/internal/v2client/client.go
+++ b/internal/v2client/client.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"strings"
 
+	"code.cloudfoundry.org/cli/plugin"
 	"github.com/cloudfoundry-community/go-cfclient"
-	"github.com/cloudfoundry/cli/plugin"
 )
 
 // Client -


### PR DESCRIPTION
In order to prevent divergance between cf-cli dependency import paths, the paths for code.cloudfoundry.org/cli and github.com/cloudfoundry/cli should be consolidated