### PR TITLE
Build for darwin arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 before:
   hooks:
     - go mod download
@@ -10,6 +11,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
   - id: linux-windows
     main: ./cmd/reportusage/main.go
     goos:


### PR DESCRIPTION
I needed an arm64 arch for Darwin on an Apple silicon MacBook. I think that this change will make it a normal part of the release process. (It worked for me using `goreleaser build --snapshot`.)